### PR TITLE
cuda

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 default = ["onnx", "coreml"]
 onnx = []
 coreml = []
+cuda = []
 
 [build-dependencies]
 # We're very permissive here with bindgen due to https://github.com/rust-lang/cargo/issues/5237

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,7 @@ fn main() {
             .header("src/onnx/bindings.h")
             .whitelist_var("ORT_API_VERSION")
             .whitelist_function("OrtGetApiBase")
+            .whitelist_function("OrtSessionOptionsAppendExecutionProvider_CUDA")
             .whitelist_type("OrtApi")
             .layout_tests(false)
             .generate()

--- a/src/onnx/api.rs
+++ b/src/onnx/api.rs
@@ -152,6 +152,12 @@ impl API {
             .expect("ReleaseSession should be available")(session)
     }
 
+    pub unsafe fn release_session_options(&self, session_options: *mut sys::OrtSessionOptions) {
+        (*self.0)
+            .ReleaseSessionOptions
+            .expect("ReleaseSessionOptions should be available")(session_options)
+    }
+
     pub unsafe fn create_tensor_with_data_as_ort_value(
         &self,
         info: *const sys::OrtMemoryInfo,

--- a/src/onnx/api.rs
+++ b/src/onnx/api.rs
@@ -71,6 +71,16 @@ impl API {
         ))
     }
 
+    pub unsafe fn create_session_options(&self) -> Result<*mut sys::OrtSessionOptions, Error> {
+        let mut ret = std::ptr::null_mut();
+        self.consume_status((*self.0)
+            .CreateSessionOptions
+            .expect("CreateSessionOptions should be available")(
+            &mut ret
+        ))?;
+        Ok(ret)
+    }
+
     pub unsafe fn create_session(
         &self,
         env: *const sys::OrtEnv,

--- a/src/onnx/bindings.h
+++ b/src/onnx/bindings.h
@@ -1,1 +1,2 @@
+#include <cuda_provider_factory.h>
 #include <onnxruntime_c_api.h>

--- a/src/onnx/mod.rs
+++ b/src/onnx/mod.rs
@@ -102,9 +102,12 @@ impl Environment {
             .map_err(|_| NewSessionError::MalformedModelPath)?;
         unsafe {
             let allocator = self.api.get_allocator_with_default_options()?;
+            let sess_options = self.api.create_session_options()?;
+
+            sys::OrtSessionOptionsAppendExecutionProvider_CUDA(sess_options, 0);
             let sess = scopeguard::guard(
                 self.api
-                    .create_session(self.inner, model_path.as_ptr(), std::ptr::null())?,
+                    .create_session(self.inner, model_path.as_ptr(), sess_options)?,
                 |ptr| self.api.release_session(ptr),
             );
 

--- a/vendor/onnxruntime/include/cuda_provider_factory.h
+++ b/vendor/onnxruntime/include/cuda_provider_factory.h
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "onnxruntime_c_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \param device_id cuda device id, starts from zero.
+ */
+ORT_API_STATUS(OrtSessionOptionsAppendExecutionProvider_CUDA,
+               _In_ OrtSessionOptions* options, int device_id);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
tested with cuda 11.2, onnxruntime 1.6.0, nvidia titan xp, arch linux

idk how to make this smartly decide whether to use cuda on runtime. we could pass it in as an argument in `new_session` I guess?

![pic](https://s.dllu.net/4MGnMwlYLAnqQJbZ.png)