### PR TITLE
distribute coreml sessions across metal devices

### DIFF
--- a/src/coreml/mod.rs
+++ b/src/coreml/mod.rs
@@ -113,8 +113,8 @@ impl Drop for OutputTensor {
 static MODEL_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 impl MLModel {
-    /// Creates a new model from the given path. Models created by this function will be evenly
-    /// amongst available Metal devices.
+    /// Creates a new model from the given path. Models created by this function will be
+    /// distributed evenly amongst available Metal devices.
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, NewMLModelError> {
         let path = match CString::new(path.as_ref().as_os_str().as_bytes()) {
             Ok(s) => s,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(all(feature = "coreml", target_os = "macos"))]
 pub mod coreml;
@@ -31,8 +30,6 @@ pub enum NewSessionError {
     UnsupportedFormat,
 }
 
-static SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
-
 impl Environment {
     pub fn new() -> Result<Self, NewEnvironmentError> {
         Ok(Self {
@@ -43,16 +40,11 @@ impl Environment {
 
     pub fn new_session<P: AsRef<Path>>(&self, model_path: P) -> Result<Session, NewSessionError> {
         let model_path = model_path.as_ref();
-        let session_number = SESSION_COUNT.fetch_add(1, Ordering::SeqCst);
-
         Ok(match model_path.extension().and_then(|s| s.to_str()) {
             #[cfg(feature = "onnx")]
-            Some("onnx") => {
-                let _ = session_number;
-                Session::ONNX(self.onnx.new_session(model_path)?)
-            }
+            Some("onnx") => Session::ONNX(self.onnx.new_session(model_path)?),
             #[cfg(all(feature = "coreml", target_os = "macos"))]
-            Some("mlmodel") => Session::CoreML(coreml::MLModel::new(model_path, session_number)?),
+            Some("mlmodel") => Session::CoreML(coreml::MLModel::new(model_path)?),
             _ => return Err(NewSessionError::UnsupportedFormat),
         })
     }


### PR DESCRIPTION
Before: All CoreML models would be loaded to a single GPU.
After: CoreML models are evenly distributed:

![Screen Shot 2021-05-22 at 1 38 54 AM](https://user-images.githubusercontent.com/1731074/119215986-03211c00-ba9f-11eb-9a5b-f9ac894a1f49.png)